### PR TITLE
Use native macOS APIs for drive listing

### DIFF
--- a/darwin/disklist.h
+++ b/darwin/disklist.h
@@ -1,0 +1,35 @@
+#ifndef DISKLIST_H
+#define DISKLIST_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    char *device;
+    char *displayName;
+    char *description;
+    uint64_t size;
+    char **mountpoints;
+    int mountpointsCount;
+    char *raw;
+    bool protected;
+    bool system;
+} DriveInfo;
+
+typedef struct {
+    DriveInfo *drives;
+    int count;
+} DriveList;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DriveList* GetDriveList(void);
+void FreeDriveList(DriveList* list);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DISKLIST_H

--- a/darwin/disklist.mm
+++ b/darwin/disklist.mm
@@ -1,0 +1,160 @@
+#import <Foundation/Foundation.h>
+#import <DiskArbitration/DiskArbitration.h>
+#include "disklist.h"
+#include <string>
+#include <vector>
+
+bool IsDiskPartition(NSString *disk) {
+    NSPredicate *partitionRegEx = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"disk\\d+s\\d+"];
+    return [partitionRegEx evaluateWithObject:disk];
+}
+
+NSNumber *DictionaryGetNumber(CFDictionaryRef dict, const void *key) {
+    return (NSNumber*)CFDictionaryGetValue(dict, key);
+}
+
+DriveInfo CreateDriveInfo(NSString *diskBsdName, CFDictionaryRef diskDescription) {
+    DriveInfo info = {};
+    
+    std::string devicePath = "/dev/" + std::string([diskBsdName UTF8String]);
+    info.device = strdup(devicePath.c_str());
+    info.displayName = strdup(devicePath.c_str());
+    
+    NSString *mediaContent = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionMediaContentKey);
+    NSString *mediaName = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionMediaNameKey);
+    std::string description;
+    if (mediaContent) {
+        description = [mediaContent UTF8String];
+        if (mediaName) {
+            description += " ";
+            description += [mediaName UTF8String];
+        }
+    } else if (mediaName) {
+        description = [mediaName UTF8String];
+    }
+    info.description = strdup(description.c_str());
+    
+    info.size = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaSizeKey) unsignedLongValue];
+    
+    std::string rawPath = "/dev/r" + std::string([diskBsdName UTF8String]);
+    info.raw = strdup(rawPath.c_str());
+    
+    info.protected = ![DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaWritableKey) boolValue];
+    
+    bool isInternal = [DictionaryGetNumber(diskDescription, kDADiskDescriptionDeviceInternalKey) boolValue];
+    bool isRemovable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaRemovableKey) boolValue];
+    info.system = isInternal && !isRemovable;
+    
+    return info;
+}
+
+extern "C" {
+
+DriveList* GetDriveList(void) {
+    DriveList* result = (DriveList*)malloc(sizeof(DriveList));
+    std::vector<DriveInfo> drives;
+    
+    DASessionRef session = DASessionCreate(kCFAllocatorDefault);
+    if (session == nil) {
+        result->drives = NULL;
+        result->count = 0;
+        return result;
+    }
+    
+    NSArray *volumeKeys = [NSArray arrayWithObjects:NSURLVolumeNameKey, NSURLVolumeLocalizedNameKey, nil];
+    NSArray *volumePaths = [[NSFileManager defaultManager] mountedVolumeURLsIncludingResourceValuesForKeys:volumeKeys options:0];
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSArray *paths = [fileManager contentsOfDirectoryAtPath:@"/dev" error:nil];
+    
+    for (NSString *path in paths) {
+        if (![path hasPrefix:@"disk"] || IsDiskPartition(path)) {
+            continue;
+        }
+        
+        DADiskRef disk = DADiskCreateFromBSDName(kCFAllocatorDefault, session, [path UTF8String]);
+        if (disk == nil) {
+            continue;
+        }
+        
+        CFDictionaryRef diskDescription = DADiskCopyDescription(disk);
+        if (diskDescription == nil) {
+            CFRelease(disk);
+            continue;
+        }
+        
+        DriveInfo info = CreateDriveInfo(path, diskDescription);
+        
+        // Get mountpoints
+        std::vector<std::string> mountpoints;
+        for (NSURL *volumePath in volumePaths) {
+            DADiskRef volumeDisk = DADiskCreateFromVolumePath(kCFAllocatorDefault, session, (__bridge CFURLRef)volumePath);
+            if (volumeDisk == nil) {
+                continue;
+            }
+            
+            const char *bsdnameChar = DADiskGetBSDName(volumeDisk);
+            if (bsdnameChar == nil) {
+                CFRelease(volumeDisk);
+                continue;
+            }
+            
+            std::string partitionBsdName = std::string(bsdnameChar);
+            std::string diskBsdName = partitionBsdName.substr(0, partitionBsdName.find("s", 5));
+            
+            if (diskBsdName == [path UTF8String]) {
+                mountpoints.push_back([[volumePath path] UTF8String]);
+            }
+            
+            CFRelease(volumeDisk);
+        }
+        
+        // Copy mountpoints to DriveInfo
+        info.mountpointsCount = mountpoints.size();
+        if (info.mountpointsCount > 0) {
+            info.mountpoints = (char**)malloc(sizeof(char*) * info.mountpointsCount);
+            for (int i = 0; i < info.mountpointsCount; i++) {
+                info.mountpoints[i] = strdup(mountpoints[i].c_str());
+            }
+        } else {
+            info.mountpoints = NULL;
+        }
+        
+        drives.push_back(info);
+        
+        CFRelease(diskDescription);
+        CFRelease(disk);
+    }
+    
+    CFRelease(session);
+    
+    // Copy drives to result
+    result->count = drives.size();
+    result->drives = (DriveInfo*)malloc(sizeof(DriveInfo) * result->count);
+    memcpy(result->drives, drives.data(), sizeof(DriveInfo) * result->count);
+    
+    return result;
+}
+
+void FreeDriveList(DriveList* list) {
+    if (list == NULL) return;
+    
+    for (int i = 0; i < list->count; i++) {
+        DriveInfo *info = &list->drives[i];
+        free(info->device);
+        free(info->displayName);
+        free(info->description);
+        free(info->raw);
+        if (info->mountpoints) {
+            for (int j = 0; j < info->mountpointsCount; j++) {
+                free(info->mountpoints[j]);
+            }
+            free(info->mountpoints);
+        }
+    }
+    
+    free(list->drives);
+    free(list);
+}
+
+}

--- a/drive_darwin.go
+++ b/drive_darwin.go
@@ -2,150 +2,47 @@
 
 package godrivelist
 
+/*
+#cgo CFLAGS: -x objective-c -I${SRCDIR}/darwin
+#cgo LDFLAGS: -framework Foundation -framework DiskArbitration
+#include "disklist.h"
+*/
+import "C"
 import (
-        "encoding/xml"
-        "os/exec"
-        "strings"
+        "unsafe"
 )
 
-type diskutilList struct {
-        XMLName xml.Name `xml:"plist"`
-        Dict    struct {
-                Array struct {
-                        Dict []struct {
-                                Key    []string `xml:"key"`
-                                String []string `xml:"string"`
-                                Int    []int64  `xml:"integer"`
-                                Bool   []bool   `xml:"false,true"`
-                        } `xml:"dict"`
-                } `xml:"array"`
-        } `xml:"dict"`
-}
-
-type dictValue struct {
-        stringVal string
-        intVal    int64
-        boolVal   bool
-        valueType string // "string", "int", or "bool"
-}
-
-func findValueByKey(dict struct {
-        Key    []string `xml:"key"`
-        String []string `xml:"string"`
-        Int    []int64  `xml:"integer"`
-        Bool   []bool   `xml:"false,true"`
-}, searchKey string) dictValue {
-        valueMap := make(map[string]int)
-        for i, key := range dict.Key {
-                valueMap[key] = i
-        }
-
-        if idx, exists := valueMap[searchKey]; exists {
-                switch searchKey {
-                case "Size", "TotalSize":
-                        if idx < len(dict.Int) {
-                                return dictValue{intVal: dict.Int[idx], valueType: "int"}
-                        }
-                case "Internal", "Ejectable", "WritableMedia":
-                        if idx < len(dict.Bool) {
-                                return dictValue{boolVal: dict.Bool[idx], valueType: "bool"}
-                        }
-                default:
-                        if idx < len(dict.String) {
-                                return dictValue{stringVal: dict.String[idx], valueType: "string"}
-                        }
-                }
-        }
-        return dictValue{} // Return empty value if not found or index out of bounds
-}
-
 func list() ([]Drive, error) {
-        // Use diskutil to get drive information
-        cmd := exec.Command("diskutil", "list", "-plist")
-        output, err := cmd.Output()
-        if err != nil {
-                return nil, err
-        }
+        driveList := C.GetDriveList()
+        defer C.FreeDriveList(driveList)
 
-        var plist diskutilList
-        if err := xml.Unmarshal(output, &plist); err != nil {
-                return nil, err
-        }
+        drives := make([]Drive, driveList.count)
+        driveSlice := unsafe.Slice(driveList.drives, driveList.count)
 
-        var drives []Drive
-        for _, dict := range plist.Dict.Array.Dict {
-                var device, description string
-                var size int64
+        for i := 0; i < int(driveList.count); i++ {
+                driveInfo := driveSlice[i]
+                
                 var mountpoints []Mountpoint
-
-                // Get device identifier
-                devIDValue := findValueByKey(dict, "DeviceIdentifier")
-                if devIDValue.valueType == "string" {
-                        device = "/dev/" + devIDValue.stringVal
-                } else {
-                        continue
-                }
-
-                // Get device node (overrides device identifier if present)
-                if devNodeValue := findValueByKey(dict, "DeviceNode"); devNodeValue.valueType == "string" {
-                        device = devNodeValue.stringVal
-                }
-
-                // Get volume name for description
-                if volNameValue := findValueByKey(dict, "VolumeName"); volNameValue.valueType == "string" {
-                        description = volNameValue.stringVal
-                }
-
-                // Get size
-                if sizeValue := findValueByKey(dict, "Size"); sizeValue.valueType == "int" {
-                        size = sizeValue.intVal
-                }
-
-                // Get mount point
-                if mountPointValue := findValueByKey(dict, "MountPoint"); mountPointValue.valueType == "string" && mountPointValue.stringVal != "" {
-                        mountpoints = append(mountpoints, Mountpoint{Path: mountPointValue.stringVal})
-                }
-
-                // Get additional disk info
-                cmd = exec.Command("diskutil", "info", "-plist", device)
-                output, err = cmd.Output()
-                if err != nil {
-                        continue
-                }
-
-                var infoList diskutilList
-                if err := xml.Unmarshal(output, &infoList); err != nil {
-                        continue
-                }
-
-                isSystem := false
-                isProtected := false
-
-                // Process disk info
-                for _, infoDict := range infoList.Dict.Array.Dict {
-                        if internalValue := findValueByKey(infoDict, "Internal"); internalValue.valueType == "bool" {
-                                isSystem = internalValue.boolVal
-                        }
-                        if ejectableValue := findValueByKey(infoDict, "Ejectable"); ejectableValue.valueType == "bool" {
-                                isSystem = isSystem || !ejectableValue.boolVal
-                        }
-                        if writableValue := findValueByKey(infoDict, "WritableMedia"); writableValue.valueType == "bool" {
-                                isProtected = !writableValue.boolVal
+                if driveInfo.mountpointsCount > 0 {
+                        mountpointSlice := unsafe.Slice(driveInfo.mountpoints, driveInfo.mountpointsCount)
+                        mountpoints = make([]Mountpoint, driveInfo.mountpointsCount)
+                        for j := 0; j < int(driveInfo.mountpointsCount); j++ {
+                                mountpoints[j] = Mountpoint{
+                                        Path: C.GoString(mountpointSlice[j]),
+                                }
                         }
                 }
 
-                drive := Drive{
-                        Device:      device,
-                        DisplayName: device,
-                        Description: description,
-                        Size:        size,
+                drives[i] = Drive{
+                        Device:      C.GoString(driveInfo.device),
+                        DisplayName: C.GoString(driveInfo.displayName),
+                        Description: C.GoString(driveInfo.description),
+                        Size:        int64(driveInfo.size),
                         Mountpoints: mountpoints,
-                        Raw:         strings.Replace(device, "/dev/", "/dev/r", 1),
-                        Protected:   isProtected,
-                        System:      isSystem,
+                        Raw:         C.GoString(driveInfo.raw),
+                        Protected:   bool(driveInfo.protected),
+                        System:      bool(driveInfo.system),
                 }
-
-                drives = append(drives, drive)
         }
 
         return drives, nil


### PR DESCRIPTION
This PR rewrites the macOS implementation to use native APIs instead of shelling out to diskutil:

1. Use DiskArbitration framework:
   - Direct access to disk information
   - Better performance
   - More reliable

2. Improve disk information:
   - Accurate descriptions (e.g., "GUID_partition_scheme")
   - Correct sizes from disk properties
   - Proper mountpoint handling

3. Add memory management:
   - Safe C/Go memory handling
   - Proper cleanup of resources
   - No memory leaks

4. Match expected output format:
   - Correct description format
   - Accurate size values
   - Proper system/protected flags

The implementation now matches the node.js drivelist behavior and output format.